### PR TITLE
Define it before you use it!

### DIFF
--- a/R/lsat_image.R
+++ b/R/lsat_image.R
@@ -1,3 +1,31 @@
+handle_errors <- function(x, path) {
+  if (x$status_code > 201) {
+    httr::stop_for_status(x)
+    unlink(path, recursive = TRUE, force = TRUE)
+  }
+}
+
+lsatGET <- function(url, dat, overwrite, ...) {
+  key <- basename(url)
+  fpath <- file.path(lsat_path(), "L8", dat$wrs_path, dat$wrs_row, dat$str, key)
+  if (file.exists(fpath)) {
+    message("File in cache")
+    return(fpath)
+  } else {
+    temp_path = tempfile()
+    res <- httr::GET(url, httr::write_disk(path = temp_path, overwrite = overwrite), ...)
+
+    #if download has failed, it will stop here
+    handle_errors(res, fpath)
+
+    dir.create(dirname(fpath), showWarnings = FALSE, recursive = TRUE)
+    file.rename(temp_path, fpath)
+
+    # return file path
+    return(fpath)
+  }
+}
+
 #' GET Landsat image(s)
 #'
 #' @export
@@ -21,32 +49,4 @@ lsat_image <- function(x, overwrite = FALSE, ...) {
   url <- sprintf("https://s3-us-west-2.amazonaws.com/landsat-pds/L8/%s/%s/%s/%s",
                  dat$wrs_path, dat$wrs_row, dat$str, x)
   lsatGET(url, dat, overwrite, ...)
-}
-
-lsatGET <- function(url, dat, overwrite, ...) {
-  key <- basename(url)
-  fpath <- file.path(lsat_path(), "L8", dat$wrs_path, dat$wrs_row, dat$str, key)
-  if (file.exists(fpath)) {
-    message("File in cache")
-    return(fpath)
-  } else {
-    temp_path = tempfile()
-    res <- GET(url, write_disk(path = temp_path, overwrite = overwrite), ...)
-
-    #if download has failed, it will stop here
-    handle_errors(res, fpath)
-
-    dir.create(dirname(fpath), showWarnings = FALSE, recursive = TRUE)
-    file.rename(temp_path, fpath)
-
-    # return file path
-    return(fpath)
-  }
-}
-
-handle_errors <- function(x, path) {
-  if (x$status_code > 201) {
-    stop_for_status(x)
-    unlink(path, recursive = TRUE, force = TRUE)
-  }
 }


### PR DESCRIPTION
Good coding practice generally is that if fun2 calls fun1, fun1 should be defined prior to fun2 in the file. In some languages it's the difference between compilation and non-compilation; while R is not one of those the most readable code is the code that fits the expectations of the most people, so I've rearranged so that lsatGET and similar are defined prior, not after, the functions using them.

(Similarly, included httr:: explicitly to make clear where functions are coming from to anyone reading the code. Plus, CRAN likes it.)
